### PR TITLE
ENHANCEMENT DatabaseCheck returns a PHP error if the table doesn't exist...

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Register checks in your own `_config.php` - see the `_config.php` in this module
 
 ## Available checks
 
- * `DatabaseCheck`: Check that the connection to the database is working, by looking for records in some table. By default, Member will be checked.
+ * `DatabaseCheck`: Check that the connection to the database is working, by ensuring that the table exists and that the table contain some records.
  * `URLCheck`: Check that a given URL is functioning, by default, the homepage.
  * `HasFunctionCheck`: Check that the given function exists.
     This can be used to check that PHP modules or features are installed.

--- a/code/checks/DatabaseCheck.php
+++ b/code/checks/DatabaseCheck.php
@@ -5,7 +5,8 @@
 
 
 /**
- * Check that the connection to the database is working, by looking for records in some table.
+ * Check that the connection to the database is working, by ensuring that the table exists and that
+ * the table contain some records.
  * By default, Member will be checked.
  * 
  * @param $checkTable The table that will be checked.
@@ -18,6 +19,11 @@ class DatabaseCheck implements EnvironmentCheck {
 	}
 	
 	function check() {
+
+		if(!DB::getConn()->hasTable($this->checkTable)) {
+			return array(EnvironmentCheck::ERROR, "$this->checkTable not present in the database");
+		}
+
 		$count = DB::query("SELECT COUNT(*) FROM \"$this->checkTable\"")->value();
 		
 		if($count > 0) {


### PR DESCRIPTION
Fixes #6, uses `DB::getConn()->hasTable()` and documentation has been updated to reflect the change
