### PR TITLE
Avoid 100% CPU on curl_multi_exec

### DIFF
--- a/code/checks/ExternalURLCheck.php
+++ b/code/checks/ExternalURLCheck.php
@@ -45,7 +45,8 @@ class ExternalURLCheck implements EnvironmentCheck {
 		// Execute the handles
 		do {
 			$mrc = curl_multi_exec($mh, $active);
-		} while ($mrc == CURLM_CALL_MULTI_PERFORM);
+			curl_multi_select($mh);
+		} while ($active > 0);
 
 		while ($active && $mrc == CURLM_OK) {
 			if (curl_multi_select($mh) != -1) {


### PR DESCRIPTION
Never finishes (up to max_execlution_limit) on PHP 5.4.24.

See http://nz1.php.net/curl_multi_exec#113002
and http://www.adrianworlddesign.com/Knowledge-Base/php/Download-content-with-cURL/Doing-curlmultiexec-the-right-way
