### PR TITLE
FIX Update config API, Logger alias, dotenv config, remove PHP 5.5, other fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   - DB=MYSQL CORE_RELEASE=4

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
  * Minimum versions required:
   * SilverStripe 4.x
-  * PHP 5.5+
+  * PHP 5.6+
  * PHP 7 supported
 
 ## [1.2.0]

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
     },
     "autoload": {
         "psr-4": {
-            "SilverStripe\\EnvironmentCheck\\": "src/",
+            "SilverStripe\\EnvironmentCheck\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "SilverStripe\\EnvironmentCheck\\Tests\\": "tests/"
         }
     }

--- a/license.md
+++ b/license.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016, SilverStripe Limited
+Copyright (c) 2017, SilverStripe Limited
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This module adds an API for running environment checks to your API.
 ## Requirements
 
 * SilverStripe 4.x
-* PHP 5.5+
+* PHP 5.6+
 
 For SilverStripe 3.x support, please use a `1.x` tagged release.
 
@@ -99,7 +99,7 @@ solutions like pingdom.com.
 
 You can also have the environment checker email results with the following configuration:
 
-```yml
+```yaml
 SilverStripe\EnvironmentCheck\EnvironmentChecker:
   email_results: true
   to_email_address: support@test.com
@@ -110,7 +110,7 @@ Errors can be logged via the standard SilverStripe PSR-3 compatible logging. Eac
 entry. You can choose to enable logging separately for warnings and errors, identified through the
 result of `EnvironmentCheck->check()`.
 
-```yml
+```yaml
 SilverStripe\EnvironmentCheck\EnvironmentChecker:
   log_results_warning: true
   log_results_error: true
@@ -123,11 +123,11 @@ trying to access it on a live or test environment, it will respond with a 403 HT
 an administrator on the site.
 
 You may wish to have an automated service check `dev/check` periodically, but not want to open it up for public access.
-You can enable basic authentication by defining the following in your environment:
+You can enable basic authentication by defining the following in your environment (`.env` file):
 
-```php
-define('ENVCHECK_BASICAUTH_USERNAME', 'test');
-define('ENVCHECK_BASICAUTH_PASSWORD', 'password');
+```
+ENVCHECK_BASICAUTH_USERNAME="test"
+ENVCHECK_BASICAUTH_PASSWORD="password"
 ```
 
 Now if you access `dev/check` in a browser it will pop up a basic auth popup, and if the submitted username and password

--- a/src/Checks/DatabaseCheck.php
+++ b/src/Checks/DatabaseCheck.php
@@ -13,6 +13,9 @@ use SilverStripe\ORM\DB;
  */
 class DatabaseCheck implements EnvironmentCheck
 {
+    /**
+     * @var string
+     */
     protected $checkTable;
 
     /**
@@ -33,15 +36,15 @@ class DatabaseCheck implements EnvironmentCheck
     public function check()
     {
         if (!DB::get_schema()->hasTable($this->checkTable)) {
-            return array(EnvironmentCheck::ERROR, "$this->checkTable not present in the database");
+            return [EnvironmentCheck::ERROR, "$this->checkTable not present in the database"];
         }
 
         $count = DB::query("SELECT COUNT(*) FROM \"$this->checkTable\"")->value();
 
         if ($count > 0) {
-            return array(EnvironmentCheck::OK, '');
+            return [EnvironmentCheck::OK, ''];
         }
 
-        return array(EnvironmentCheck::WARNING, "$this->checkTable queried ok but has no records");
+        return [EnvironmentCheck::WARNING, "$this->checkTable queried ok but has no records"];
     }
 }

--- a/src/Checks/ExternalURLCheck.php
+++ b/src/Checks/ExternalURLCheck.php
@@ -19,7 +19,7 @@ class ExternalURLCheck implements EnvironmentCheck
     /**
      * @var array
      */
-    protected $urls = array();
+    protected $urls = [];
 
     /**
      * @var Int Timeout in seconds.
@@ -47,7 +47,7 @@ class ExternalURLCheck implements EnvironmentCheck
     {
         $urls = $this->getURLs();
 
-        $chs = array();
+        $chs = [];
         foreach ($urls as $url) {
             $ch = curl_init();
             $chs[] = $ch;
@@ -75,7 +75,7 @@ class ExternalURLCheck implements EnvironmentCheck
         }
 
         $hasError = false;
-        $msgs = array();
+        $msgs = [];
         foreach ($chs as $ch) {
             $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
             $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -103,10 +103,10 @@ class ExternalURLCheck implements EnvironmentCheck
         curl_multi_close($mh);
 
         if ($hasError) {
-            return array(EnvironmentCheck::ERROR, implode(', ', $msgs));
+            return [EnvironmentCheck::ERROR, implode(', ', $msgs)];
         }
 
-        return array(EnvironmentCheck::OK, implode(', ', $msgs));
+        return [EnvironmentCheck::OK, implode(', ', $msgs)];
     }
 
     /**
@@ -114,13 +114,13 @@ class ExternalURLCheck implements EnvironmentCheck
      */
     protected function getCurlOpts($url)
     {
-        return array(
+        return [
             CURLOPT_URL => $url,
             CURLOPT_HEADER => 0,
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_FAILONERROR => 1,
             CURLOPT_TIMEOUT => $this->timeout,
-        );
+        ];
     }
 
     /**

--- a/src/Checks/FileAccessibilityAndValidationCheck.php
+++ b/src/Checks/FileAccessibilityAndValidationCheck.php
@@ -79,14 +79,14 @@ class FileAccessibilityAndValidationCheck implements EnvironmentCheck
     public function check()
     {
         $origStage = Versioned::get_reading_mode();
-        Versioned::set_reading_mode('Live');
+        Versioned::set_reading_mode(Versioned::LIVE);
 
         $files = $this->getFiles();
         if ($files) {
             $fileTypeValidateFunc = $this->fileTypeValidateFunc;
             if (method_exists($this, $fileTypeValidateFunc)) {
-                $invalidFiles = array();
-                $validFiles = array();
+                $invalidFiles = [];
+                $validFiles = [];
 
                 foreach ($files as $file) {
                     if ($this->$fileTypeValidateFunc($file)) {
@@ -103,23 +103,23 @@ class FileAccessibilityAndValidationCheck implements EnvironmentCheck
                         $validFileList .= $vf . PHP_EOL;
                     }
                     if ($fileTypeValidateFunc == 'noVidation') {
-                        $checkReturn = array(
+                        $checkReturn = [
                             EnvironmentCheck::OK,
                             sprintf('At least these file(s) accessible: %s', $validFileList)
-                        );
+                        ];
                     } else {
-                        $checkReturn = array(
+                        $checkReturn = [
                             EnvironmentCheck::OK,
                             sprintf(
                                 'At least these file(s) passed file type validate function "%s": %s',
                                 $fileTypeValidateFunc,
                                 $validFileList
                             )
-                        );
+                        ];
                     }
                 } else {
                     if (count($invalidFiles) == 0) {
-                        $checkReturn = array(EnvironmentCheck::OK, 'All files valideted');
+                        $checkReturn = [EnvironmentCheck::OK, 'All files valideted'];
                     } else {
                         $invalidFileList = PHP_EOL;
                         foreach ($invalidFiles as $vf) {
@@ -127,19 +127,19 @@ class FileAccessibilityAndValidationCheck implements EnvironmentCheck
                         }
 
                         if ($fileTypeValidateFunc == 'noVidation') {
-                            $checkReturn = array(
+                            $checkReturn = [
                                 EnvironmentCheck::ERROR,
                                 sprintf('File(s) not accessible: %s', $invalidFileList)
-                            );
+                            ];
                         } else {
-                            $checkReturn = array(
+                            $checkReturn = [
                                 EnvironmentCheck::ERROR,
                                 sprintf(
                                     'File(s) not passing the file type validate function "%s": %s',
                                     $fileTypeValidateFunc,
                                     $invalidFileList
                                 )
-                            );
+                            ];
                         }
                     }
                 }

--- a/src/Checks/FileAgeCheck.php
+++ b/src/Checks/FileAgeCheck.php
@@ -98,8 +98,8 @@ class FileAgeCheck implements EnvironmentCheck
     {
         $cutoffTime =  strtotime($this->relativeAge, DBDatetime::now()->Format('U'));
         $files = $this->getFiles();
-        $invalidFiles = array();
-        $validFiles = array();
+        $invalidFiles = [];
+        $validFiles = [];
         $checkFn = $this->checkFn;
         $allValid = true;
         if ($files) {
@@ -111,7 +111,7 @@ class FileAgeCheck implements EnvironmentCheck
                 } else {
                     $invalidFiles[] = $file;
                     if ($this->checkType == self::CHECK_ALL) {
-                        return array(
+                        return [
                             EnvironmentCheck::ERROR,
                             sprintf(
                                 'File "%s" doesn\'t match age check (compare %s: %s, actual: %s)',
@@ -120,7 +120,7 @@ class FileAgeCheck implements EnvironmentCheck
                                 date('c', $cutoffTime),
                                 date('c', $fileTime)
                             )
-                        );
+                        ];
                     }
                 }
             }
@@ -128,15 +128,15 @@ class FileAgeCheck implements EnvironmentCheck
 
         // If at least one file was valid, count as passed
         if ($this->checkType == self::CHECK_SINGLE && count($invalidFiles) < count($files)) {
-            return array(EnvironmentCheck::OK, '');
+            return [EnvironmentCheck::OK, ''];
         }
         if (count($invalidFiles) == 0) {
-            return array(EnvironmentCheck::OK, '');
+            return [EnvironmentCheck::OK, ''];
         }
-        return array(
+        return [
             EnvironmentCheck::ERROR,
             sprintf('No files matched criteria (%s %s)', $this->compareOperand, date('c', $cutoffTime))
-        );
+        ];
     }
 
     /**

--- a/src/Checks/FileWriteableCheck.php
+++ b/src/Checks/FileWriteableCheck.php
@@ -58,7 +58,7 @@ class FileWriteableCheck implements EnvironmentCheck
                     $message .= 'We recommend that you make the file writeable.';
                 } else {
                     $groups = posix_getgroups();
-                    $groupList = array();
+                    $groupList = [];
                     foreach ($groups as $group) {
                         $groupInfo = posix_getgrgid($group);
                         if (in_array($currentOwner['name'], $groupInfo['members'])) {
@@ -79,9 +79,9 @@ class FileWriteableCheck implements EnvironmentCheck
                 $message = "The webserver user needs to be able to write to this file:\n$filename";
             }
 
-            return array(EnvironmentCheck::ERROR, $message);
+            return [EnvironmentCheck::ERROR, $message];
         }
 
-        return array(EnvironmentCheck::OK, '');
+        return [EnvironmentCheck::OK, ''];
     }
 }

--- a/src/Checks/HasClassCheck.php
+++ b/src/Checks/HasClassCheck.php
@@ -32,8 +32,8 @@ class HasClassCheck implements EnvironmentCheck
     public function check()
     {
         if (class_exists($this->className)) {
-            return array(EnvironmentCheck::OK, 'Class ' . $this->className.' exists');
+            return [EnvironmentCheck::OK, 'Class ' . $this->className.' exists'];
         }
-        return array(EnvironmentCheck::ERROR, 'Class ' . $this->className.' doesn\'t exist');
+        return [EnvironmentCheck::ERROR, 'Class ' . $this->className.' doesn\'t exist'];
     }
 }

--- a/src/Checks/HasFunctionCheck.php
+++ b/src/Checks/HasFunctionCheck.php
@@ -32,8 +32,8 @@ class HasFunctionCheck implements EnvironmentCheck
     public function check()
     {
         if (function_exists($this->functionName)) {
-            return array(EnvironmentCheck::OK, $this->functionName . '() exists');
+            return [EnvironmentCheck::OK, $this->functionName . '() exists'];
         }
-        return array(EnvironmentCheck::ERROR, $this->functionName . '() doesn\'t exist');
+        return [EnvironmentCheck::ERROR, $this->functionName . '() doesn\'t exist'];
     }
 }

--- a/src/Checks/SMTPConnectCheck.php
+++ b/src/Checks/SMTPConnectCheck.php
@@ -59,21 +59,21 @@ class SMTPConnectCheck implements EnvironmentCheck
     {
         $f = @fsockopen($this->host, $this->port, $errno, $errstr, $this->timeout);
         if (!$f) {
-            return array(
+            return [
                 EnvironmentCheck::ERROR,
                 sprintf("Couldn't connect to SMTP on %s:%s (Error: %s %s)", $this->host, $this->port, $errno, $errstr)
-            );
+            ];
         }
 
         fwrite($f, "HELO its_me\r\n");
         $response = fread($f, 26);
         if (substr($response, 0, 3) != '220') {
-            return array(
+            return [
                 EnvironmentCheck::ERROR,
                 sprintf('Invalid mail server response: %s', $response)
-            );
+            ];
         }
 
-        return array(EnvironmentCheck::OK, '');
+        return [EnvironmentCheck::OK, ''];
     }
 }

--- a/src/Checks/SolrIndexCheck.php
+++ b/src/Checks/SolrIndexCheck.php
@@ -33,16 +33,16 @@ class SolrIndexCheck implements EnvironmentCheck
      */
     public function check()
     {
-        $brokenCores = array();
+        $brokenCores = [];
 
         /**
          * @todo Revisit this when silverstripe/fulltextsearch has 4.x compat
          */
         if (!class_exists('\\Solr')) {
-            return array(
+            return [
                 EnvironmentCheck::ERROR,
                 'Class `Solr` not found. Is the fulltextsearch module installed?'
-            );
+            ];
         }
 
         $service = \Solr::service();
@@ -54,12 +54,12 @@ class SolrIndexCheck implements EnvironmentCheck
         }
 
         if (!empty($brokenCores)) {
-            return array(
+            return [
                 EnvironmentCheck::ERROR,
                 'The following indexes are unavailable: ' . implode($brokenCores, ', ')
-            );
+            ];
         }
 
-        return array(EnvironmentCheck::OK, 'Expected indexes are available.');
+        return [EnvironmentCheck::OK, 'Expected indexes are available.'];
     }
 }

--- a/src/Checks/URLCheck.php
+++ b/src/Checks/URLCheck.php
@@ -24,7 +24,7 @@ class URLCheck implements EnvironmentCheck
      */
     protected $testString;
 
-    /*
+    /**
      * @param string $url The URL to check, relative to the site (homepage is '').
      * @param string $testString An optional piece of text to search for on the homepage.
      */
@@ -45,19 +45,19 @@ class URLCheck implements EnvironmentCheck
         $response = Director::test($this->url);
 
         if ($response->getStatusCode() != 200) {
-            return array(
+            return [
                 EnvironmentCheck::ERROR,
                 sprintf('Error retrieving "%s" (Code: %d)', $this->url, $response->getStatusCode())
-            );
+            ];
         } elseif ($this->testString && (strpos($response->getBody(), $this->testString) === false)) {
-            return array(
+            return [
                 EnvironmentCheck::WARNING,
                 sprintf('Success retrieving "%s", but string "%s" not found', $this->url, $this->testString)
-            );
+            ];
         }
-        return array(
+        return [
             EnvironmentCheck::OK,
             sprintf('Success retrieving "%s"', $this->url)
-        );
+        ];
     }
 }

--- a/src/Controllers/DevCheckController.php
+++ b/src/Controllers/DevCheckController.php
@@ -15,9 +15,9 @@ class DevCheckController extends Controller
     /**
      * @var array
      */
-    public static $allowed_actions = array(
+    public static $allowed_actions = [
         'index'
-    );
+    ];
 
     /**
      * Permission code to check for access to this controller.

--- a/src/Controllers/DevHealthController.php
+++ b/src/Controllers/DevHealthController.php
@@ -15,9 +15,9 @@ class DevHealthController extends Controller
     /**
      * @var array
      */
-    public static $allowed_actions = array(
+    public static $allowed_actions = [
         'index'
-    );
+    ];
 
     /**
      * @return EnvironmentChecker

--- a/src/EnvironmentCheckSuite.php
+++ b/src/EnvironmentCheckSuite.php
@@ -43,7 +43,7 @@ class EnvironmentCheckSuite extends Object
     /**
      * @var array
      */
-    protected $checks = array();
+    protected $checks = [];
 
     /**
      * Associative array of named checks registered via the config system. Each check should specify:
@@ -53,7 +53,7 @@ class EnvironmentCheckSuite extends Object
      *
      * @var array
      */
-    private static $registered_checks = array();
+    private static $registered_checks = [];
 
     /**
      * Associative array of named suites registered via the config system. Each suite should enumerate
@@ -61,7 +61,7 @@ class EnvironmentCheckSuite extends Object
      *
      * @var array
      */
-    private static $registered_suites = array();
+    private static $registered_suites = [];
 
     /**
      * Load checks for this suite from the configuration system. This is an alternative to the
@@ -130,20 +130,20 @@ class EnvironmentCheckSuite extends Object
      */
     protected function checkInstances()
     {
-        $output = array();
+        $output = [];
         foreach ($this->checks as $check) {
             list($checkClass, $checkTitle) = $check;
             if (is_string($checkClass)) {
                 $checkInst = Object::create_from_string($checkClass);
                 if ($checkInst instanceof EnvironmentCheck) {
-                    $output[] = array($checkInst, $checkTitle);
+                    $output[] = [$checkInst, $checkTitle];
                 } else {
                     throw new InvalidArgumentException(
                         "Bad EnvironmentCheck: '$checkClass' - the named class doesn't implement EnvironmentCheck"
                     );
                 }
             } elseif ($checkClass instanceof EnvironmentCheck) {
-                $output[] = array($checkClass, $checkTitle);
+                $output[] = [$checkClass, $checkTitle];
             } else {
                 throw new InvalidArgumentException("Bad EnvironmentCheck: " . var_export($check, true));
             }
@@ -162,7 +162,7 @@ class EnvironmentCheckSuite extends Object
         if (!$title) {
             $title = is_string($check) ? $check : get_class($check);
         }
-        $this->checks[] = array($check, $title);
+        $this->checks[] = [$check, $title];
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////
@@ -170,7 +170,7 @@ class EnvironmentCheckSuite extends Object
     /**
      * @var array
      */
-    protected static $instances = array();
+    protected static $instances = [];
 
     /**
      * Return a named instance of EnvironmentCheckSuite.
@@ -197,7 +197,7 @@ class EnvironmentCheckSuite extends Object
     public static function register($names, $check, $title = null)
     {
         if (!is_array($names)) {
-            $names = array($names);
+            $names = [$names];
         }
 
         foreach ($names as $name) {
@@ -210,6 +210,6 @@ class EnvironmentCheckSuite extends Object
      */
     public static function reset()
     {
-        self::$instances = array();
+        self::$instances = [];
     }
 }

--- a/src/EnvironmentCheckSuiteResult.php
+++ b/src/EnvironmentCheckSuiteResult.php
@@ -37,12 +37,12 @@ class EnvironmentCheckSuiteResult extends ViewableData
      */
     public function addResult($status, $message, $checkIdentifier)
     {
-        $this->details->push(new ArrayData(array(
+        $this->details->push(new ArrayData([
             'Check' => $checkIdentifier,
             'Status' => $this->statusText($status),
             'StatusCode' => $status,
             'Message' => $message,
-        )));
+        ]));
 
         $this->worst = max($this->worst, $status);
     }
@@ -84,11 +84,11 @@ class EnvironmentCheckSuiteResult extends ViewableData
      */
     public function toJSON()
     {
-        $result = array(
+        $result = [
             'Status' => $this->Status(),
             'ShouldPass' => $this->ShouldPass(),
-            'Checks' => array()
-        );
+            'Checks' => []
+        ];
         foreach ($this->details as $detail) {
             $result['Checks'][] = $detail->toMap();
         }

--- a/src/EnvironmentChecker.php
+++ b/src/EnvironmentChecker.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\EnvironmentCheck;
 
 use Psr\Log\LogLevel;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPResponse;
@@ -27,9 +28,9 @@ class EnvironmentChecker extends RequestHandler
     /**
      * @var array
      */
-    private static $url_handlers = array(
+    private static $url_handlers = [
         '' => 'index',
-    );
+    ];
 
     /**
      * @var string
@@ -101,12 +102,12 @@ class EnvironmentChecker extends RequestHandler
     public function init($permission = 'ADMIN')
     {
         // if the environment supports it, provide a basic auth challenge and see if it matches configured credentials
-        if (defined('ENVCHECK_BASICAUTH_USERNAME') && defined('ENVCHECK_BASICAUTH_PASSWORD')) {
+        if (getenv('ENVCHECK_BASICAUTH_USERNAME') && getenv('ENVCHECK_BASICAUTH_PASSWORD')) {
             if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
                 // authenticate the input user/pass with the configured credentials
                 if (!(
-                        $_SERVER['PHP_AUTH_USER'] == ENVCHECK_BASICAUTH_USERNAME
-                        && $_SERVER['PHP_AUTH_PW'] == ENVCHECK_BASICAUTH_PASSWORD
+                        $_SERVER['PHP_AUTH_USER'] == getenv('ENVCHECK_BASICAUTH_USERNAME')
+                        && $_SERVER['PHP_AUTH_PW'] == getenv('ENVCHECK_BASICAUTH_PASSWORD')
                     )
                 ) {
                     $response = new HTTPResponse(null, 401);
@@ -185,12 +186,12 @@ class EnvironmentChecker extends RequestHandler
             $response->setStatusCode($this->errorCode);
         }
 
-        $resultText = $result->customise(array(
+        $resultText = $result->customise([
             'URL' => Director::absoluteBaseURL(),
             'Title' => $this->title,
             'Name' => $this->checkSuiteName,
             'ErrorCode' => $this->errorCode,
-        ))->renderWith(__CLASS__);
+        ])->renderWith(__CLASS__);
 
         if ($this->config()->email_results && !$result->ShouldPass()) {
             $email = new Email(
@@ -239,7 +240,7 @@ class EnvironmentChecker extends RequestHandler
      */
     public function log($message, $level)
     {
-        Injector::inst()->get('Logger')->log($level, $message);
+        Injector::inst()->get(LoggerInterface::class)->log($level, $message);
     }
 
     /**
@@ -259,7 +260,7 @@ class EnvironmentChecker extends RequestHandler
     public static function set_from_email_address($from)
     {
         Deprecation::notice('2.0', 'Use config API instead');
-        Config::inst()->update(__CLASS__, 'from_email_address', $from);
+        Config::modify()->set(__CLASS__, 'from_email_address', $from);
     }
 
     /**
@@ -279,7 +280,7 @@ class EnvironmentChecker extends RequestHandler
     public static function set_to_email_address($to)
     {
         Deprecation::notice('2.0', 'Use config API instead');
-        Config::inst()->update(__CLASS__, 'to_email_address',  $to);
+        Config::modify()->set(__CLASS__, 'to_email_address',  $to);
     }
 
     /**
@@ -299,7 +300,7 @@ class EnvironmentChecker extends RequestHandler
     public static function set_email_results($results)
     {
         Deprecation::notice('2.0', 'Use config API instead');
-        Config::inst()->update(__CLASS__, 'email_results', $results);
+        Config::modify()->set(__CLASS__, 'email_results', $results);
     }
 
     /**

--- a/tests/Checks/DatabaseCheckTest.php
+++ b/tests/Checks/DatabaseCheckTest.php
@@ -30,10 +30,10 @@ class DatabaseCheckTest extends SapphireTest
 
         $check = new DatabaseCheck();
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::OK,
             ''
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Checks/ExternalURLCheckTest.php
+++ b/tests/Checks/ExternalURLCheckTest.php
@@ -21,10 +21,10 @@ class ExternalURLCheckTest extends SapphireTest
 
         $check = new ExternalURLCheck('http://missing-site/');
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::ERROR,
             'Success retrieving "http://missing-site/" (Code: 404)'
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Checks/FileWritableCheckTest.php
+++ b/tests/Checks/FileWritableCheckTest.php
@@ -19,10 +19,10 @@ class FileWritableCheckTest extends SapphireTest
     {
         $check = new FileWriteableCheck(TEMP_FOLDER);
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::OK,
             ''
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Checks/HasClassCheckTest.php
+++ b/tests/Checks/HasClassCheckTest.php
@@ -19,10 +19,10 @@ class HasClassCheckTest extends SapphireTest
     {
         $check = new HasClassCheck('foo');
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::ERROR,
             'Class foo doesn\'t exist'
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }
@@ -31,10 +31,10 @@ class HasClassCheckTest extends SapphireTest
     {
         $check = new HasClassCheck('stdClass');
 
-        $expected = array(
-                EnvironmentCheck::OK,
-                'Class stdClass exists',
-        );
+        $expected = [
+            EnvironmentCheck::OK,
+            'Class stdClass exists',
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Checks/HasFunctionCheckTest.php
+++ b/tests/Checks/HasFunctionCheckTest.php
@@ -19,10 +19,10 @@ class HasFunctionCheckTest extends SapphireTest
     {
         $check = new HasFunctionCheck('foo');
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::ERROR,
             'foo() doesn\'t exist'
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }
@@ -31,10 +31,10 @@ class HasFunctionCheckTest extends SapphireTest
     {
         $check = new HasFunctionCheck('class_exists');
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::OK,
             'class_exists() exists'
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Checks/URLCheckTest.php
+++ b/tests/Checks/URLCheckTest.php
@@ -19,10 +19,10 @@ class URLCheckTest extends SapphireTest
     {
         $check = new URLCheck('foo', 'bar');
 
-        $expected = array(
+        $expected = [
             EnvironmentCheck::ERROR,
             'Error retrieving "foo" (Code: 404)'
-        );
+        ];
 
         $this->assertEquals($expected, $check->check());
     }

--- a/tests/Controllers/DevCheckControllerTest.php
+++ b/tests/Controllers/DevCheckControllerTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\EnvironmentCheck\Tests\Controllers;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\EnvironmentCheck\Controllers\DevCheckController;
+use SilverStripe\EnvironmentCheck\EnvironmentChecker;
 
 /**
  * Class DevCheckControllerTest
@@ -27,6 +28,6 @@ class DevCheckControllerTest extends SapphireTest
 
         $request = new HTTPRequest('GET', 'example.com');
 
-        $this->assertInstanceOf('SilverStripe\\EnvironmentCheck\\EnvironmentChecker', $controller->index($request));
+        $this->assertInstanceOf(EnvironmentChecker::class, $controller->index($request));
     }
 }

--- a/tests/Controllers/DevHealthControllerTest.php
+++ b/tests/Controllers/DevHealthControllerTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\EnvironmentCheck\Tests\Controllers;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\EnvironmentCheck\Controllers\DevHealthController;
+use SilverStripe\EnvironmentCheck\EnvironmentChecker;
 
 /**
  * Class DevHealthControllerTest
@@ -30,12 +31,12 @@ class DevHealthControllerTest extends SapphireTest
         // we need to fake authenticated access as BasicAuth::requireLogin doesn't like empty
         // permission type strings, which is what health check uses.
 
-        define('ENVCHECK_BASICAUTH_USERNAME', 'foo');
-        define('ENVCHECK_BASICAUTH_PASSWORD', 'bar');
+        putenv('ENVCHECK_BASICAUTH_USERNAME="foo"');
+        putenv('ENVCHECK_BASICAUTH_PASSWORD="bar"');
 
         $_SERVER['PHP_AUTH_USER'] = 'foo';
         $_SERVER['PHP_AUTH_PW'] = 'bar';
 
-        $this->assertInstanceOf('SilverStripe\\EnvironmentCheck\\EnvironmentChecker', $controller->index($request));
+        $this->assertInstanceOf(EnvironmentChecker::class, $controller->index($request));
     }
 }


### PR DESCRIPTION
Remove PHP 5.5 from Travis configuration. Dotenv used for environment management now,
examples and tests updated to use putenv instead of define. Logger alias update to
LoggerInterface. Update mutable config API calls. Replace array declaration with
short version: []. Update license year.

Resolves #41