### PR TITLE
BUGFIX move allowed_actions to private static

### DIFF
--- a/src/Controllers/DevCheckController.php
+++ b/src/Controllers/DevCheckController.php
@@ -15,7 +15,7 @@ class DevCheckController extends Controller
     /**
      * @var array
      */
-    public static $allowed_actions = [
+    private static $allowed_actions = [
         'index'
     ];
 

--- a/src/Controllers/DevHealthController.php
+++ b/src/Controllers/DevHealthController.php
@@ -15,7 +15,7 @@ class DevHealthController extends Controller
     /**
      * @var array
      */
-    public static $allowed_actions = [
+    private static $allowed_actions = [
         'index'
     ];
 


### PR DESCRIPTION
Prevents this error on dev/build:

```
Fatal error: Uncaught LogicException: SilverStripe\EnvironmentCheck\Controllers\DevCheckController::allowed_actions is not private but overrides a private static config in parent class SilverStripe\Control\Controller in /var/www/mysite/releases/876d889fe9527efee9e2a42cc46c4feaeb590b4b/vendor/silverstripe/config/src/Transformer/PrivateStaticTransformer.php:116
```