### PR TITLE
Ensure compatibility with SS 3.7 & PHP 7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -19,3 +19,8 @@
 // EnvironmentCheckSuite::register('check', 'FileWriteableCheck("assets")', "Is assets/ writeable?");
 // EnvironmentCheckSuite::register('check', 'FileWriteableCheck("' . TEMP_FOLDER . '")', "Is the temp folder writeable?");
 
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) {
+    class_alias('Object', 'SS_Object');
+}

--- a/code/EnvironmentCheckSuite.php
+++ b/code/EnvironmentCheckSuite.php
@@ -19,7 +19,7 @@
  *
  * $result = EnvironmentCheckSuite::inst('health')->run();
  */
-class EnvironmentCheckSuite extends Object
+class EnvironmentCheckSuite extends SS_Object
 {
     /**
      * Name of this suite.
@@ -121,7 +121,7 @@ class EnvironmentCheckSuite extends Object
         foreach ($this->checks as $check) {
             list($checkClass, $checkTitle) = $check;
             if (is_string($checkClass)) {
-                $checkInst = Object::create_from_string($checkClass);
+                $checkInst = SS_Object::create_from_string($checkClass);
                 if ($checkInst instanceof EnvironmentCheck) {
                     $output[] = array($checkInst, $checkTitle);
                 } else {


### PR DESCRIPTION
This fixes the SS 3.7+ & PHP 7.2 compatibility, effectively renaming calls to Object:: to SS_Object:: and aliasing SS_Object to Object for backwards compatibility (older versions of SilverStripe) [as described here](https://docs.silverstripe.org/en/3/changelogs/3.7.0/#for-module-authors).

If you don't mind, could you also make this a tagged release please, seems like the last 10 commits from the 1.2 branch  have not been tagged either.