### PR TITLE
MNT Bump guzzle requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/versioned": "^1.0",
-        "guzzlehttp/guzzle": "^6.3.3"
+        "guzzlehttp/guzzle": "^6.3.3 || ^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ This module adds an API for running environment checks to your API.
 ## Requirements
 
 * SilverStripe 4.x
-* PHP 5.6+
+* PHP 7.3
 
 For SilverStripe 3.x support, please use a `1.x` tagged release.
 

--- a/tests/Checks/CacheHeadersCheckTest.php
+++ b/tests/Checks/CacheHeadersCheckTest.php
@@ -55,7 +55,7 @@ class CacheHeadersCheckTest extends SapphireTest
             new Response(200, ['Cache-Control' => 'must-revalidate', 'ETag' => '123']),
             new Response(200, ['Cache-Control' =>'no-cache', 'ETag' => '123']),
             new Response(200, ['ETag' => '123']),
-            new Response(200, ['Cache-Control' =>'private, no-store', ' ETag' => '123']),
+            new Response(200, ['Cache-Control' =>'private, no-store', 'ETag' => '123']),
         ]);
 
         $handler = HandlerStack::create($mock);


### PR DESCRIPTION
We keep getting composer warning because `intervention/image` requires `guzzlehttp/psr7 (~1.1 || ^2.0)` but `environmentcheck` will only let you install `1`. So if you install `environmentcheck` later in your project set up you get a weird composer warning.