### PR TITLE
removed double quotes in .env example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,8 +131,8 @@ You may wish to have an automated service check `dev/check` periodically, but no
 You can enable basic authentication by defining the following in your environment (`.env` file):
 
 ```
-ENVCHECK_BASICAUTH_USERNAME="test"
-ENVCHECK_BASICAUTH_PASSWORD="password"
+ENVCHECK_BASICAUTH_USERNAME=test
+ENVCHECK_BASICAUTH_PASSWORD=password
 ```
 
 Now if you access `dev/check` in a browser it will pop up a basic auth popup, and if the submitted username and password


### PR DESCRIPTION
As mentioned in [ !73 ](https://github.com/silverstripe/silverstripe-environmentcheck/issues/73) the double quotes in the example are note needed.

In fact; In the current README `Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')` will return `"test"` and `Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')` will return `"password"`.

So the example is not working if you expect that the strings `test` and `password` will match.