### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.10",
         "silverstripe/versioned": "^1.0",
         "guzzlehttp/guzzle": "^6.3.3 || ^7"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
