### PR TITLE
Add Response Time column to health check table

### DIFF
--- a/src/EnvironmentCheckSuite.php
+++ b/src/EnvironmentCheckSuite.php
@@ -99,7 +99,7 @@ class EnvironmentCheckSuite
     }
 
     /**
-     * Run this test suite and return the result code of the worst result.
+     * Run this test suite and return the result code of the worst result and the time it took.
      *
      * @return EnvironmentCheckSuiteResult
      */
@@ -110,13 +110,15 @@ class EnvironmentCheckSuite
         foreach ($this->checkInstances() as $check) {
             list($checkClass, $checkTitle) = $check;
             try {
+                $startTime = microtime(true);
                 list($status, $message) = $checkClass->check();
+                $responseTime = number_format((microtime(true) - $startTime), 4, '.', '') . 's';
             // If the check fails, register that as an error
             } catch (Exception $e) {
                 $status = EnvironmentCheck::ERROR;
                 $message = $e->getMessage();
             }
-            $result->addResult($status, $message, $checkTitle);
+            $result->addResult($status, $message, $checkTitle, $responseTime);
         }
 
         return $result;

--- a/src/EnvironmentCheckSuite.php
+++ b/src/EnvironmentCheckSuite.php
@@ -109,6 +109,7 @@ class EnvironmentCheckSuite
 
         foreach ($this->checkInstances() as $check) {
             list($checkClass, $checkTitle) = $check;
+            $responseTime = 'Not Found';
             try {
                 $startTime = microtime(true);
                 list($status, $message) = $checkClass->check();

--- a/src/EnvironmentCheckSuiteResult.php
+++ b/src/EnvironmentCheckSuiteResult.php
@@ -35,12 +35,13 @@ class EnvironmentCheckSuiteResult extends ViewableData
      * @param string $message
      * @param string $checkIdentifier
      */
-    public function addResult($status, $message, $checkIdentifier)
+    public function addResult($status, $message, $checkIdentifier, $responseTime)
     {
         $this->details->push(new ArrayData([
             'Check' => $checkIdentifier,
             'Status' => $this->statusText($status),
             'StatusCode' => $status,
+            'ResponseTime' => $responseTime,
             'Message' => $message,
         ]));
 

--- a/src/EnvironmentCheckSuiteResult.php
+++ b/src/EnvironmentCheckSuiteResult.php
@@ -34,8 +34,9 @@ class EnvironmentCheckSuiteResult extends ViewableData
      * @param int $status
      * @param string $message
      * @param string $checkIdentifier
+     * @param string $responseTime
      */
-    public function addResult($status, $message, $checkIdentifier, $responseTime)
+    public function addResult($status, $message, $checkIdentifier, $responseTime = null)
     {
         $this->details->push(new ArrayData([
             'Check' => $checkIdentifier,

--- a/templates/SilverStripe/EnvironmentCheck/EnvironmentChecker.ss
+++ b/templates/SilverStripe/EnvironmentCheck/EnvironmentChecker.ss
@@ -66,9 +66,9 @@
 
         <% if $IncludeDetails %>
         <table>
-            <tr><th>Check</th> <th>Status</th> <th>Message</th></tr>
+            <tr><th>Check</th> <th>Status</th> <th>Response Time</th> <th>Message</th></tr>
             <% loop $Details %>
-            <tr><td>$Check</td> <td class="$Status">$Status</td> <td>$Message.XML</td></tr>
+            <tr><td>$Check</td> <td class="$Status">$Status</td> <td class="$ResponseTime">$ResponseTime</td> <td>$Message.XML</td></tr>
             <% end_loop %>
         </table>
         <% end_if %>


### PR DESCRIPTION
**Motivation:** When debugging failing external URL checks we were unable to tell if requests were getting timed out or actually failing.

Values formatted to 4 decimal places. Happy to change formatting or column label if necessary.


![add-response-time-environment-checker-screenshot](https://user-images.githubusercontent.com/33613949/171750463-dab7d8a2-776d-484c-9cb6-fc709e93ae04.png)

