### PR TITLE
FIX Respect strict-typing of Factory interface

### DIFF
--- a/src/Services/ClientFactory.php
+++ b/src/Services/ClientFactory.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\EnvironmentCheck\Services;
 
+use Psr\Http\Client\ClientInterface;
 use GuzzleHttp\Client as GuzzleClient;
 use SilverStripe\Core\Injector\Factory;
 use SilverStripe\Core\Config\Configurable;
@@ -28,7 +29,7 @@ class ClientFactory implements Factory
      *
      * {@inheritdoc}
      */
-    public function create($service, array $params = [])
+    public function create(string $service, array $params = []): ClientInterface
     {
         return new GuzzleClient($this->getConfig($params));
     }


### PR DESCRIPTION
Respects the new strict typing in https://github.com/silverstripe/silverstripe-framework/pull/11300
That PR is required for Ci to go green.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11145