### PR TITLE
FIX Correct bugs with Basic Auth option

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,5 +1,6 @@
 ---
 Name: environmentcheckroutes
+Before: coreroutes
 ---
 SilverStripe\Control\Director:
   rules:

--- a/src/EnvironmentChecker.php
+++ b/src/EnvironmentChecker.php
@@ -105,7 +105,8 @@ class EnvironmentChecker extends RequestHandler
     public function init($permission = 'ADMIN')
     {
         if (!$this->canAccess(null, $permission)) {
-            // if the environment supports it, provide a basic auth challenge and see if it matches configured credentials
+            // if the environment supports it, provide a basic auth challenge
+            // and see if it matches configured credentials
             if (Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')
                 && Environment::getEnv('ENVCHECK_BASICAUTH_PASSWORD')
             ) {

--- a/src/EnvironmentChecker.php
+++ b/src/EnvironmentChecker.php
@@ -4,6 +4,7 @@ namespace SilverStripe\EnvironmentCheck;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPResponse;
@@ -108,9 +109,10 @@ class EnvironmentChecker extends RequestHandler
             && Environment::getEnv('ENVCHECK_BASICAUTH_PASSWORD')
         ) {
             // Check that details are both provided, and match
-            if (empty($_SERVER['PHP_AUTH_USER']) || empty($_SERVER['PHP_AUTH_PW'])
-                || $_SERVER['PHP_AUTH_USER'] != Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')
-                || $_SERVER['PHP_AUTH_PW'] != Environment::getEnv('ENVCHECK_BASICAUTH_PASSWORD')
+            $request = Controller::curr()->request;
+            if (empty($request->getHeader('PHP_AUTH_USER')) || empty($request->getHeader('PHP_AUTH_PW'))
+                || $request->getHeader('PHP_AUTH_USER') != Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')
+                || $request->getHeader('PHP_AUTH_PW') != Environment::getEnv('ENVCHECK_BASICAUTH_PASSWORD')
             ) {
                 // Fail check with basic auth challenge
                 $response = new HTTPResponse(null, 401);


### PR DESCRIPTION
## Description
Fixes multiple issues preventing use of the [Basic Auth configuration](https://github.com/silverstripe/silverstripe-environmentcheck?tab=readme-ov-file#authentication)

## Manual testing steps
1. Set up the [Basic Auth environment variables](https://github.com/silverstripe/silverstripe-environmentcheck?tab=readme-ov-file#authentication)
2. Access the dev/check page as both:
   1. A logged in Admin user - expected behaviour is that the user will not need to enter any additional credentials to view the page
   2. Without being logged in - expected behaviour is that Basic Auth authentication will be available for the username and password set up in step 1 only

## Issues
- #73 
- #92 
- #116 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
