### PR TITLE
FIX Allow logged in user with permissions to bypass basic auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.3",
         "silverstripe/versioned": "^2",
         "guzzlehttp/guzzle": "^7"
     },

--- a/src/EnvironmentChecker.php
+++ b/src/EnvironmentChecker.php
@@ -103,6 +103,11 @@ class EnvironmentChecker extends RequestHandler
      */
     public function init($permission = 'ADMIN')
     {
+        $canAccess = $this->canAccess(null, $permission);
+        // Allow bypassing basic-auth check if the user is logged in with the required permission
+        if ($canAccess) {
+            return;
+        }
         // if the environment supports it, provide a basic auth challenge and see if it matches configured credentials
         if (Environment::getEnv('ENVCHECK_BASICAUTH_USERNAME')
             && Environment::getEnv('ENVCHECK_BASICAUTH_PASSWORD')
@@ -117,13 +122,6 @@ class EnvironmentChecker extends RequestHandler
                 $response->addHeader('WWW-Authenticate', "Basic realm=\"Environment check\"");
                 throw new HTTPResponse_Exception($response);
             }
-        } elseif (!$this->canAccess(null, $permission)) {
-            // Fail check with silverstripe login challenge
-            $result = Security::permissionFailure(
-                $this,
-                "You must have the {$permission} permission to access this check"
-            );
-            throw new HTTPResponse_Exception($result);
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-environmentcheck/issues/116

In order to manually test this you need to set your environment type to test or live as dev environments will bypass the basic-auth check