### PR TITLE
MNT remove testing as composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "type": "silverstripe-vendormodule",
     "keywords": [
         "silverstripe",
-        "testing",
         "environment",
         "check"
     ],


### PR DESCRIPTION
`testing` is a special keyword in Composer and recent versions output a warning (The package you required is recommended to be placed in require-dev (because it is tagged as "testing") but you did not use --dev)